### PR TITLE
Fix build-from-source instructions in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,20 @@ plugins {
 git clone https://github.com/sharph/zellij-worktree
 cd zellij-worktree
 cargo build --release
-cp target/wasm32-wasip1/release/zellij_worktree.wasm ~/.config/zellij/plugins/
+mkdir -p ~/.config/zellij/plugins
+cp target/wasm32-wasip1/release/zellij-worktree.wasm ~/.config/zellij/plugins/
+```
+
+Then update your config to use the local plugin:
+
+```kdl
+shared_except "locked" "tab" {
+    bind "Ctrl w" {
+        LaunchOrFocusPlugin "file:~/.config/zellij/plugins/zellij-worktree.wasm" {
+            floating true
+        }
+    }
+}
 ```
 
 ## Usage


### PR DESCRIPTION
## Summary
- Fix wasm filename: `zellij_worktree.wasm` → `zellij-worktree.wasm` (hyphen, not underscore)
- Add `mkdir -p` for the plugins directory which may not exist
- Add config example showing how to use the locally built plugin with `file:` prefix

Fixes #1